### PR TITLE
Use the first repo provider to init UI

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -43,6 +43,7 @@ from .config import ConfigHandler
 from .health import HealthHandler
 from .launcher import Launcher
 from .log import log_request
+from .repoproviders import RepoProvider
 from .registry import DockerRegistry
 from .main import MainHandler, ParameterizedMainHandler, LegacyRedirectHandler
 from .repoproviders import (GitHubRepoProvider, GitRepoProvider,
@@ -454,6 +455,18 @@ class BinderHub(Application):
         List of Repo Providers to register and try
         """
     )
+
+    @validate('repo_providers')
+    def _validate_repo_providers(self, proposal):
+        """trait validator to ensure there is at least one repo provider"""
+        if not proposal.value:
+            raise TraitError("Please provide at least one repo provider")
+
+        if any([not issubclass(provider, RepoProvider) for provider in proposal.value.values()]):
+            raise TraitError("Repository providers should inherit from 'binderhub.RepoProvider'")
+
+        return proposal.value
+
     concurrent_build_limit = Integer(
         32,
         config=True,

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -37,9 +37,9 @@
       {% block form %}
       <form id="build-form" class="form jumbotron">
         <h4 id="form-header" class='row'>Build and launch a repository</h4>
-        <input type="hidden" id="provider_prefix" value="gh"/>
+        <input type="hidden" id="provider_prefix" value="{{repo_providers.keys() | list | first}}"/> 
         <div class="form-group row">
-          <label for="repository">Git repository URL (github.com, gitlab.com or self-host)</label>
+          <label for="repository">{{(repo_providers.values() | list | first).labels.text}}</label>
           <div class="input-group">
             <div class="input-group-btn" id="url-type-btn">
               <button type="button" class="btn btn-secondary dropdown-toggle"
@@ -47,7 +47,7 @@
                 title="Specify source of repository"
               >
               <span id="provider_prefix-selected">
-              GitHub
+                {{(repo_providers.values() | list | first).display_name}}
               </span>
               <span class="caret"></span>
               </button>
@@ -57,19 +57,19 @@
                 {% endfor %}
               </ul>
             </div>
-            <input class="form-control" type="text" id="repository" data-lpignore="true" placeholder="GitHub repository name or link"/>
+            <input class="form-control" type="text" id="repository" data-lpignore="true" placeholder="{{(repo_providers.values() | list | first).labels.text}}"/>
           </div>
         </div>
         <div class="form-row row">
           <div class="form-group col-md-4">
-            <label for="ref">Git branch, tag, or commit</label>
-            <input class="form-control" type="text" id="ref" placeholder="master"/>
+            <label for="ref">{{(repo_providers.values() | list | first).labels.tag_text}}</label>
+            <input class="form-control" type="text" id="ref" placeholder="HEAD"/>
           </div>
           <div class="form-group col-md-6">
-            <label for="filepath"></label>
+            <label for="filepath">Path to a notebook file (optional)</label>
             <div class="input-group">
               <input class="form-control" type="text" id="filepath"
-                placeholder=""
+                placeholder="Path to a notebook file (optional)"
               />
               <div class="input-group-btn" id="url-or-file-btn">
                 <button type="button" class="btn btn-secondary dropdown-toggle"
@@ -102,7 +102,8 @@
               <label>Copy the URL below and share your Binder with others:</label>
             </div>
             <div class="url-row">
-              <pre id="basic-url-snippet" data-default="Fill in the fields to see a URL for sharing your Binder."></pre>
+              <pre id="basic-url-snippet" data-default="Fill in the fields to see a URL for sharing your Binder."
+              >Fill in the fields to see a URL for sharing your Binder.</pre>
               <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}" data-clipboard-target="#basic-url-snippet" alt="Copy to clipboard">
             </div>
         </div>

--- a/binderhub/tests/test_app.py
+++ b/binderhub/tests/test_app.py
@@ -2,6 +2,13 @@
 
 from subprocess import check_output
 import sys
+import pytest
+
+from traitlets import TraitError
+
+from binderhub.app import BinderHub
+from binderhub.repoproviders import (RepoProvider, GitLabRepoProvider, GitHubRepoProvider)
+
 
 def test_help():
     check_output([sys.executable, '-m', 'binderhub', '-h'])
@@ -9,3 +16,19 @@ def test_help():
 def test_help_all():
     check_output([sys.executable, '-m', 'binderhub', '--help-all'])
 
+def test_repo_providers():
+    b = BinderHub()
+
+    class Provider(RepoProvider):
+        pass
+
+    b.repo_providers = dict(gh=GitHubRepoProvider, gl=GitLabRepoProvider)
+    b.repo_providers = dict(p=Provider)
+
+    class BadProvider():
+        pass
+
+    wrong_repo_providers = [GitHubRepoProvider, {}, 'GitHub', BadProvider]
+    for repo_providers in wrong_repo_providers:
+        with pytest.raises(TraitError):
+            b.repo_providers = repo_providers


### PR DESCRIPTION
Hi @GeorgianaElena !

That looks great, thank you for starting this improvement!
I tried to implement the last few missing things :
- use the first repo provider to init UI
- add default text values, consistent with js, to prevent flickering
- validate repo_providers to avoid empty dict and force values to inherit from `binderhub.RepoProvider`
- add repo_providers test

Maybe the `repo_providers` validation if too strict, and we should not force inheritance from `binderhub.RepoProvider`. Let me know.

Do you think it will be enough to make https://github.com/jupyterhub/binderhub/pull/1038 mergeable?
cc @jtpio

Thanks!